### PR TITLE
Add hammer to slaves

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,6 +4,7 @@ class robottelo_slave::install {
     'python-devel',
     'python-pip',
     'python-virtualenv',
+    'rubygem-hammer_cli_katello',
   ])
 
 }


### PR DESCRIPTION
- Becaue its needed for builders, but generally useful both upstream and
  downstrean so not added specifically to downstream builders.