### PR TITLE
Fixed Puppet getting stuck when run during boot

### DIFF
--- a/files/jenkins-slave.service
+++ b/files/jenkins-slave.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Jenkins slave service
 Requires=network.target
-After=multi-user.target
+After=network.target
 
 [Service]
 Type=simple


### PR DESCRIPTION
It was a deadlock between multi-user.target invoking puppet and puppet waiting for multi-user.target (because it was trying to start jenkins-slave.service)
