### PR TITLE
Fixed hammer install dependency issue

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -4,10 +4,12 @@ class robottelo_slave::install {
     'python-devel',
     'python-pip',
     'python-virtualenv',
+    'ruby-devel',
   ])
 
   ensure_packages(['hammer_cli_katello'], {
     'provider' => 'gem'
   })
+  Package['ruby-devel'] -> Package['hammer_cli_katello']
 
 }


### PR DESCRIPTION
Hammer gem requires ruby-devel
